### PR TITLE
fix plugin enable error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/addons/rhubarb_lip_sync_tool/plugin.gd
+++ b/addons/rhubarb_lip_sync_tool/plugin.gd
@@ -59,7 +59,8 @@ func _enter_tree() -> void:
 	
 	add_autoload_singleton("RhubarbInterface", "res://addons/rhubarb_lip_sync_tool/RhubarbInterface.gd")
 	
-	RhubarbInterface.ensure_directories_exist()
+	var rin:RhubarbInterfaceNode = RhubarbInterfaceNode.new()
+	rin.ensure_directories_exist()
 
 func _exit_tree() -> void:
 	remove_inspector_plugin(composer_inspector_plugin)


### PR DESCRIPTION
fix problem that godot can not enable the plugin because the autoload doesn't exist when parsing (pre-executing) plugin.gd gdscript file on fresh install